### PR TITLE
server: always add a hint that the blueprint was created by MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ For stdio mode:
 make run-stdio
 ```
 
+### Additional info
+
+You can set the environment variable `IMAGE_BUILDER_MCP_DISABLE_DESCRIPTION_WATERMARK` to `True` to avoid
+adding a hint to `image-builder-mcp` in newly created blueprints.
+
 ## Integrations
 
 ### VSCode

--- a/src/image_builder_mcp/server.py
+++ b/src/image_builder_mcp/server.py
@@ -400,6 +400,9 @@ class ImageBuilderMCP(FastMCP):  # pylint: disable=too-many-instance-attributes
         except ValueError as e:
             return self.no_auth_error(e)
         try:
+            if os.environ.get("IMAGE_BUILDER_MCP_DISABLE_DESCRIPTION_WATERMARK", "").lower() != "true":
+                desc_parts = [data.get("description", ""), "Blueprint created via image-builder-mcp"]
+                data["description"] = "\n".join(filter(None, desc_parts))
             # TBD: programmatically check against openapi
             response = client.make_request(
                 "blueprints", method="POST", data=data)


### PR DESCRIPTION
Always add a hint that the blueprint was created by MCP.
Can be disabled with `IMAGE_BUILDER_MCP_DISABLE_DESCRIPTION_WATERMARK = True`