### PR TITLE
claude_desktop: change to newer DXT format

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,4 +68,4 @@ jobs:
           gh release create "$TAG" \
             --title "Release $TAG" \
             --generate-notes \
-            image-builder-"$TAG".cdx
+            image-builder-"$TAG".dxt

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ __pycache__
 .coverage
 dictionary.dic
 test_config.json
-*.cdx
+*.dxt

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TAG ?= UNKNOWN
 
 build-claude-extension: ## Build the Claude extension
 	sed -i "s/---VERSION---/$(TAG)/g" claude_desktop/manifest.json
-	zip -j image-builder-$(TAG).cdx claude_desktop/*
+	zip -j image-builder-$(TAG).dxt claude_desktop/*
 	sed -i "s/$(TAG)/---VERSION---/g" claude_desktop/manifest.json
 
 lint: ## Run linting with pre-commit

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ then integrate:
 
 For Claude Desktop there is an extension file in the release section of the project.
 
-Just download the `image-builder-mcp*.cdx` file and add this in Claude Desktop with
+Just download the `image-builder-mcp*.dxt` file and add this in Claude Desktop with
 
 `Settings -> Extensions -> Advanced Extensions Settings -> Install Extension…`
 

--- a/claude_desktop/manifest.json
+++ b/claude_desktop/manifest.json
@@ -1,6 +1,5 @@
 {
-  "cdx_version": "0.2",
-  "id": "com.redhat.console.image-builder",
+  "dxt_version": "0.2",
   "name": "image-builder-mcp",
   "display_name": "Image Builder MCP",
   "version": "---VERSION---",


### PR DESCRIPTION
With the recent versions of Claude Desktop
(could be >0.12.x) the format of extensions changed to DXT.